### PR TITLE
feat: Added parallelization to EMT Nuclear data conversion script

### DIFF
--- a/timelapse-colorizer-data/convert_emt_nuclear_data.py
+++ b/timelapse-colorizer-data/convert_emt_nuclear_data.py
@@ -10,16 +10,16 @@ python timelapse-colorizer-data/convert_emt_nuclear_data.py --scale 1.0 --output
 ```
 """
 
-import multiprocessing
-from typing import List, Sequence
 from aicsimageio import AICSImage
 import argparse
 import json
 import logging
+import multiprocessing
 import numpy as np
 import pandas as pd
 from pandas.core.groupby.generic import DataFrameGroupBy
 import time
+from typing import List, Sequence
 
 from data_writer_utils import (
     INITIAL_INDEX_COLUMN,


### PR DESCRIPTION
Copies the same parallelization logic from the `convert_emt_h2b_labelfree.py` script into `convert_emt_nuclear_data.py`. I'll make a separate PR to do the same for the other scripts.

Link to a newly-generated dataset working on the public build: 
https://dev-aics-dtp-001.int.allencell.org/nucmorph-colorizer/dist/index.html?dataset=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2FLOW_Matrigel_lumenoid%2Fmanifest.json&feature=Slice&t=119&color=matplotlib-cool