### PR TITLE
refactor: Made explicit methods for generating frame paths

### DIFF
--- a/documentation/DATA_FORMAT.md
+++ b/documentation/DATA_FORMAT.md
@@ -53,7 +53,7 @@ The most important file is the **manifest**, which is a JSON file that describes
 }
 ```
 
-*Note: all paths are relative to the location of the manifest file.*
+_Note: all paths are relative to the location of the manifest file._
 
 Note that the `outliers`, `centroids`, and `bounds` files are optional, but certain features of Timelapse-Colorizer won't work without them.
 
@@ -232,7 +232,7 @@ The `key` must be unique across all backdrop image sets, and must only contain l
             ...
         },
         ...
-    ] 
+    ]
 }
 ```
 
@@ -375,9 +375,9 @@ The times JSON is similar to the tracks JSON. It also contains a `data` array th
 
 ### 5. Frames
 
-*Example frame:*
+_Example frame:_
 ![Segmented cell nuclei on a black background, in various shades of green, yellow, red.](./frame_example.png)
-*Each unique color in this frame is a different object ID.*
+_Each unique color in this frame is a different object ID._
 
 **Frames** are image textures that store the object IDs for each time step in the time series. Each pixel in the image can encode a single object ID in its RGB value (`object ID = R + G*256 + B*256*256 - 1`), and background pixels are `#000000` (black).
 

--- a/documentation/DATA_FORMAT.md
+++ b/documentation/DATA_FORMAT.md
@@ -635,3 +635,23 @@ Here's a list of where Timelapse-Colorizer will check for the manifest files for
 ---
 
 </details>
+
+## FAQ
+
+### My data needs to start at a timepoint other than zero.
+
+Once you get the first frame in your dataset, you'll need to save this data to your dataset's metadata and also include the information when generating the frame paths.
+
+```python
+writer = ColorizerDatasetWriter(...)
+starting_timepoint = 5
+num_frames = 100
+
+# Generate file paths starting at some offset
+frame_paths = generate_frame_paths(num_frames, start_frame=starting_timepoint)
+writer.set_frame_paths(frame_paths)
+
+# Including starting frame number in the metadata
+metadata = ColorizerMetadata(start_frame_num=starting_timepoint)
+writer.write_manifest(metadata)
+```

--- a/timelapse-colorizer-data/convert_emt_h2b_labelfree.py
+++ b/timelapse-colorizer-data/convert_emt_h2b_labelfree.py
@@ -18,6 +18,7 @@ from data_writer_utils import (
     FeatureInfo,
     FeatureType,
     configureLogging,
+    generate_frame_paths,
     get_total_objects,
     sanitize_path_by_platform,
     scale_image,
@@ -367,11 +368,13 @@ def make_dataset(
 
     # Make the features, frame data, and manifest.
     nframes = len(grouped_frames)
+    writer.set_frame_paths(generate_frame_paths(nframes))
+
     make_features(full_dataset, writer)
     if do_frames:
         make_frames_parallel(grouped_frames, scale, writer)
 
-    writer.write_manifest(nframes, metadata=metadata)
+    writer.write_manifest(metadata=metadata)
 
 
 # TODO: Make top-level function

--- a/timelapse-colorizer-data/convert_emt_migration_data.py
+++ b/timelapse-colorizer-data/convert_emt_migration_data.py
@@ -15,6 +15,7 @@ from data_writer_utils import (
     FeatureInfo,
     FeatureType,
     configureLogging,
+    generate_frame_paths,
     make_bounding_box_array,
     sanitize_path_by_platform,
     scale_image,
@@ -231,10 +232,12 @@ def make_dataset(
 
     # Make the features, frame data, and manifest.
     nframes = len(grouped_frames)
+    writer.set_frame_paths(generate_frame_paths(nframes))
+
     make_features(full_dataset, writer)
     if do_frames:
         make_frames(grouped_frames, scale, writer)
-    writer.write_manifest(nframes, metadata=metadata)
+    writer.write_manifest(metadata=metadata)
 
 
 # TODO: Make top-level function

--- a/timelapse-colorizer-data/convert_emt_nuclear_data.py
+++ b/timelapse-colorizer-data/convert_emt_nuclear_data.py
@@ -28,6 +28,7 @@ from data_writer_utils import (
     FeatureInfo,
     FeatureType,
     configureLogging,
+    generate_frame_paths,
     get_total_objects,
     make_bounding_box_array,
     sanitize_path_by_platform,
@@ -257,10 +258,12 @@ def make_dataset(
 
     # Make the features, frame data, and manifest.
     nframes = len(grouped_frames)
+    writer.set_frame_paths(generate_frame_paths(nframes))
+
     make_features(full_dataset, writer)
     if do_frames:
         make_frames_parallel(grouped_frames, scale, writer)
-    writer.write_manifest(nframes, metadata=metadata)
+    writer.write_manifest(metadata=metadata)
 
 
 # This is stuff scientists are responsible for!!

--- a/timelapse-colorizer-data/convert_nucmorph_data.py
+++ b/timelapse-colorizer-data/convert_nucmorph_data.py
@@ -28,6 +28,7 @@ from data_writer_utils import (
     FeatureInfo,
     FeatureType,
     configureLogging,
+    generate_frame_paths,
     get_total_objects,
     make_bounding_box_array,
     sanitize_path_by_platform,
@@ -282,10 +283,12 @@ def make_dataset(output_dir="./data/", dataset="baby_bear", do_frames=True, scal
 
     # Make the features, frame data, and manifest.
     nframes = len(grouped_frames)
+    writer.set_frame_paths(generate_frame_paths(nframes))
+
     make_features(full_dataset, FEATURE_COLUMNS, dataset, writer)
     if do_frames:
         make_frames_parallel(grouped_frames, scale, writer)
-    writer.write_manifest(nframes, metadata=metadata)
+    writer.write_manifest(metadata=metadata)
 
 
 parser = argparse.ArgumentParser()

--- a/timelapse-colorizer-data/data_writer_utils.py
+++ b/timelapse-colorizer-data/data_writer_utils.py
@@ -15,6 +15,8 @@ from PIL import Image
 
 MAX_CATEGORIES = 12
 INITIAL_INDEX_COLUMN = "initialIndex"
+DEFAULT_FRAME_PREFIX = "frame_"
+DEFAULT_FRAME_SUFFIX = ".png"
 """
 Column added to reduced datasets, holding the original indices of each row.
 
@@ -103,6 +105,7 @@ class ColorizerMetadata:
     frame_units: str = ""
     frame_duration_sec: float = 0
     start_time_sec: float = 0
+    start_frame_num: int = 0
 
     def to_json(self) -> DatasetMetadata:
         return {
@@ -113,6 +116,7 @@ class ColorizerMetadata:
             },
             "startTimeSeconds": self.start_time_sec,
             "frameDurationSeconds": self.frame_duration_sec,
+            "startingFrameNumber": self.start_frame_num,
         }
 
 
@@ -319,6 +323,26 @@ def sanitize_key_name(name: str) -> str:
     return re.sub(pattern, "", name)
 
 
+def generate_frame_paths(
+    num_frames: int,
+    start_frame: int = 0,
+    file_prefix: str = DEFAULT_FRAME_PREFIX,
+    file_suffix: str = DEFAULT_FRAME_SUFFIX,
+) -> List[str]:
+    """
+    Returns a list of image file paths of length `num_frames`, with a configurable prefix, suffix,
+    and starting frame number.
+
+    By default, returns the list:
+    - `frame_0.png`
+    - `frame_1.png`
+    - `frame_2.png`
+    - `...`
+    - `frame_{num_frames - 1}.png`
+    """
+    return [file_prefix + str(i + start_frame) + file_suffix for i in range(num_frames)]
+
+
 class ColorizerDatasetWriter:
     """
     Writes provided data as Colorizer-compatible dataset files to the configured output directory.
@@ -476,9 +500,17 @@ class ColorizerDatasetWriter:
                 json.dump(bounds_json, f)
             self.manifest["bounds"] = "bounds.json"
 
+    def set_frame_paths(self, paths: List[str]) -> None:
+        """
+        Stores an ordered array of paths to image frames, to be written
+        to the manifest. Paths should be are relative to the dataset directory.
+
+        Use `generate_frame_paths()` if your frame numbers are contiguous (no gaps or skips).
+        """
+        self.manifest["frames"] = paths
+
     def write_manifest(
         self,
-        num_frames: int,
         metadata: ColorizerMetadata = None,
     ):
         """
@@ -487,39 +519,13 @@ class ColorizerDatasetWriter:
         Must be called **AFTER** all other data is written.
 
         [documentation](https://github.com/allen-cell-animated/colorizer-data/blob/main/documentation/DATA_FORMAT.md#Dataset)
-
-        `manifest.json:`
-        ```
-          frames: [frame_0.png, frame_1.png, ...]
-
-          # Names are given by `feature_names` parameter, in order.
-          features: { "feature_0_name": "feature_0.json", "feature_1_name": "feature_1.json", ... }
-
-          # per cell, same order as featureN.json files. true/false boolean values.
-          outliers: "outliers.json"
-          # per-cell track id, same format as featureN.json files
-          tracks: "tracks.json"
-          # per-cell frame index, same format as featureN.json files
-          times: "times.json"
-          # per-cell centroid. For each index i, the coordinates are (x: data[2i], y: data[2i + 1]).
-          centroids: "centroids.json"
-          # bounding boxes for each cell. For each index i, the minimum bounding box coordinates
-          # (upper left corner) are given by (x: data[4i], y: data[4i + 1]),
-          # and the maximum bounding box coordinates (lower right corner) are given by
-          # (x: data[4i + 2], y: data[4i + 3]).
-          bounds: "bounds.json"
-        ```
         """
+
         # Add the metadata
         if metadata:
             self.manifest["metadata"] = metadata.to_json()
 
-        # TODO: Write these progressively to an internal map during feature writing
-        # so we only write the files that are known? (This won't work safely across processes
-        # during parallellism though :/)
-        self.manifest["frames"] = [
-            "frame_" + str(i) + ".png" for i in range(num_frames)
-        ]
+        self.validate_dataset()
 
         with open(self.outpath + "/manifest.json", "w") as f:
             json.dump(self.manifest, f, indent=2)
@@ -530,12 +536,27 @@ class ColorizerDatasetWriter:
         self,
         seg_remapped: np.ndarray,
         frame_num: int,
+        frame_prefix: str = DEFAULT_FRAME_PREFIX,
+        frame_suffix: str = DEFAULT_FRAME_SUFFIX,
     ):
         """
         Writes the current segmented image to a PNG file in the output directory.
-        The image will be saved as `frame_{frame_num}.png`.
+        By default, the image will be saved as `frame_{frame_num}.png`.
 
         IDs for each pixel are stored in the RGBA channels of the image.
+
+        Args:
+          seg_remapped (np.ndarray[int]): A 2D numpy array of integers, where each value in the array is the object ID of the
+          segmentation that occupies that pixel.
+          frame_num (int): The frame number.
+
+        Positional args:
+          frame_prefix (str): The prefix of the file to be written. This can include subdirectory paths. By default, this is `frame_`.
+          frame_suffix (str); The suffix of the file to be written. By default, this is `.png`.
+
+        Effects:
+          Writes the ID information to an RGB image file at the path `{frame_prefix}{frame_num}{frame_suffix}`. (By default, this looks
+          like `frame_n.png`.)
 
         [documentation](https://github.com/allen-cell-animated/colorizer-data/blob/main/documentation/DATA_FORMAT.md#3-frames)
         """
@@ -547,4 +568,43 @@ class ColorizerDatasetWriter:
         seg_rgba[:, :, 2] = (seg_remapped & 0x00FF0000) >> 16
         seg_rgba[:, :, 3] = 255  # (seg2d & 0xFF000000) >> 24
         img = Image.fromarray(seg_rgba)  # new("RGBA", (xres, yres), seg2d)
-        img.save(self.outpath + "/frame_" + str(frame_num) + ".png")
+        # TODO: Automatically create subdirectories if `frame_prefix` contains them.
+        img.save(self.outpath + "/" + frame_prefix + str(frame_num) + frame_suffix)
+
+    def validate_dataset(
+        self,
+    ):
+        """
+        Logs warnings to the console if any expected files are missing.
+        """
+        if self.manifest["times"] is None:
+            logging.warn("No times JSON information provided!")
+        if not os.path.isfile(self.outpath + "/" + self.manifest["times"]):
+            logging.warn(
+                "Times JSON file does not exist at expected path '{}'".format(
+                    self.manifest["times"]
+                )
+            )
+
+        # TODO: Add validation for other required data files
+
+        if self.manifest["frames"] is None:
+            logging.warn(
+                "No frames are provided! Did you forget to call `set_frame_paths` on the writer?"
+            )
+        else:
+            # Check that all the frame paths exist
+            missing_frames = []
+            for i in range(len(self.manifest["frames"])):
+                path = self.manifest["frames"][i]
+                if not os.path.isfile(self.outpath + "/" + path):
+                    missing_frames.append([i, path])
+            if len(missing_frames) > 0:
+                logging.warn(
+                    "{} image frame(s) missing from the dataset! The following files could not be found:".format(
+                        len(missing_frames)
+                    )
+                )
+                for i in range(len(missing_frames)):
+                    index, path = missing_frames[i]
+                    logging.warn("  {}: '{}'".format(index, path))

--- a/timelapse-colorizer-data/data_writer_utils.py
+++ b/timelapse-colorizer-data/data_writer_utils.py
@@ -511,6 +511,7 @@ class ColorizerDatasetWriter:
 
     def write_manifest(
         self,
+        num_frames: int = None,
         metadata: ColorizerMetadata = None,
     ):
         """
@@ -520,6 +521,12 @@ class ColorizerDatasetWriter:
 
         [documentation](https://github.com/allen-cell-animated/colorizer-data/blob/main/documentation/DATA_FORMAT.md#Dataset)
         """
+
+        if num_frames is not None and self.manifest["frames"] is None:
+            logging.warn(
+                "ColorizerDatasetWriter: The argument `num_frames` on `write_manifest` is deprecated and will be removed in the future! Please call `set_frame_paths(generate_frame_paths(num_frames))` instead."
+            )
+            self.set_frame_paths(generate_frame_paths(num_frames))
 
         # Add the metadata
         if metadata:

--- a/timelapse-colorizer-data/data_writer_utils.py
+++ b/timelapse-colorizer-data/data_writer_utils.py
@@ -15,8 +15,6 @@ from PIL import Image
 
 MAX_CATEGORIES = 12
 INITIAL_INDEX_COLUMN = "initialIndex"
-DEFAULT_FRAME_PREFIX = "frame_"
-DEFAULT_FRAME_SUFFIX = ".png"
 """
 Column added to reduced datasets, holding the original indices of each row.
 
@@ -27,6 +25,8 @@ reduced_dataset = reduced_dataset.reset_index(drop=True)
 reduced_dataset[INITIAL_INDEX_COLUMN] = reduced_dataset.index.values
 ```
 """
+DEFAULT_FRAME_PREFIX = "frame_"
+DEFAULT_FRAME_SUFFIX = ".png"
 RESERVED_INDICES = 1
 """Reserved indices that cannot be used for cell data. 
 0 is reserved for the background."""

--- a/timelapse-colorizer-data/data_writer_utils.py
+++ b/timelapse-colorizer-data/data_writer_utils.py
@@ -6,7 +6,7 @@ import os
 import pathlib
 import platform
 import re
-from typing import Dict, List, Sequence, TypedDict, Union
+from typing import List, Sequence, TypedDict, Union
 
 import numpy as np
 import pandas as pd
@@ -608,3 +608,4 @@ class ColorizerDatasetWriter:
                 for i in range(len(missing_frames)):
                     index, path = missing_frames[i]
                     logging.warn("  {}: '{}'".format(index, path))
+                logging.warn("For auto-generated frame numbers, you may need to ")


### PR DESCRIPTION
Closes #19, "Allow frames to start at number other than zero."

Resolves an issue first encountered by @gouthamr321, where datasets that started at timepoints other than 0 would show an error when loaded into the colorizer.

This update makes the automatically-generated frame paths explicit, and adds an entry point for users to change the frame paths if needed.

Changelog:
- Adds a helper method, `generate_frame_paths`, that can be configured with an image prefix, image suffix, and a starting offset.
- Removes the `num_frames` argument from `writer.write_manifest` and replaces it with `writer.set_frame_paths`.
- The manifest now performs a validation step before writing, warning the user if there are any missing image files.