### PR TITLE
New release version: v1.0.0

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -3,7 +3,7 @@
 commit = true
 tag = true
 tag_name = "v{new_version}"
-current_version = "0.0.0"
+current_version = "1.0.0"
 
 [[tool.bumpversion.files]]
 glob = "**/*.md"

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ If using these example scripts, you'll need to run these commands in an environm
 
 ```
 # pip
-pip install git+https://github.com/allen-cell-animated/colorizer-data.git@v0.0.0
+pip install git+https://github.com/allen-cell-animated/colorizer-data.git@v1.0.0
 
 # requirements.txt
-colorizer_data @ git+https://github.com/allen-cell-animated/colorizer-data.git@0.0.0
+colorizer_data @ git+https://github.com/allen-cell-animated/colorizer-data.git@1.0.0
 ```
 
 To install a different version, replace the end of the URL with a specific version or branch, like `@vX.X.X` or `@{branch-name}`.

--- a/documentation/DATA_FORMAT.md
+++ b/documentation/DATA_FORMAT.md
@@ -1,6 +1,6 @@
 # Timelapse-Colorizer Data Format
 
-Last release: v0.0.0
+Last release: v1.0.0
 
 Timelapse-Colorizer can only load datasets that follow the defined data specification.
 


### PR DESCRIPTION
Bumps documentation and tags the release for v1.0.0!

This includes the recent auto-feature detection and refactoring, as well as adding support for background images.

*Estimated review time: <2 minutes*