### PR TITLE
fix: Missing version 'v' in README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If using these example scripts, you'll need to run these commands in an environm
 pip install git+https://github.com/allen-cell-animated/colorizer-data.git@v1.0.0
 
 # requirements.txt
-colorizer_data @ git+https://github.com/allen-cell-animated/colorizer-data.git@1.0.0
+colorizer_data @ git+https://github.com/allen-cell-animated/colorizer-data.git@v1.0.0
 ```
 
 To install a different version, replace the end of the URL with a specific version or branch, like `@vX.X.X` or `@{branch-name}`.


### PR DESCRIPTION
Oops! Missed the correct specifier for the version number in the requirements.txt instructions.