### PR TITLE
Bump version: 1.0.0 → 1.1.0

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -3,7 +3,7 @@
 commit = true
 tag = true
 tag_name = "v{new_version}"
-current_version = "1.0.0"
+current_version = "1.1.0"
 
 [[tool.bumpversion.files]]
 glob = "**/*.md"

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ If using these example scripts, you'll need to run these commands in an environm
 
 ```
 # pip
-pip install git+https://github.com/allen-cell-animated/colorizer-data.git@v1.0.0
+pip install git+https://github.com/allen-cell-animated/colorizer-data.git@v1.1.0
 
 # requirements.txt
-colorizer_data @ git+https://github.com/allen-cell-animated/colorizer-data.git@v1.0.0
+colorizer_data @ git+https://github.com/allen-cell-animated/colorizer-data.git@v1.1.0
 ```
 
 To install a different version, replace the end of the URL with a specific version or branch, like `@vX.X.X` or `@{branch-name}`.
@@ -124,9 +124,9 @@ The `type` should be either `major`, `minor`, or `patch`.
 
 #### Example
 
-Bumping major versions. The tag `v1.0.0` will be the newest tag created by `bump-my-version`.
+Bumping major versions. The tag `v1.1.0` will be the newest tag created by `bump-my-version`.
 
 ```cmd
 bump-my-version bump --tag -v major
-git push origin v1.0.0
+git push origin v1.1.0
 ```

--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ The `type` should be either `major`, `minor`, or `patch`.
 
 #### Example
 
-Bumping major versions. The tag `v1.1.0` will be the newest tag created by `bump-my-version`.
+If the current version is `v0.0.0`, bumping major versions will create the tag tag `v1.0.0`.
 
 ```cmd
 bump-my-version bump --tag -v major
-git push origin v1.1.0
+git push origin v1.0.0
 ```

--- a/colorizer_data/types.py
+++ b/colorizer_data/types.py
@@ -8,7 +8,7 @@ from typing import Dict, List, Optional, Type, TypeVar, TypedDict, Union
 Json = Union[dict, str, int, float, bool, None]
 
 
-CURRENT_VERSION = "v1.0.0"
+CURRENT_VERSION = "v1.1.0"
 DEFAULT_COLLECTION_VERSION = "v1.0"
 DEFAULT_DATASET_VERSION = "v1.0"
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
@@ -151,7 +151,7 @@ class ColorizerMetadata(DataClassJsonMixin):
     is rewritten. Starts at 0.
     """
     _writer_version: Optional[str] = CURRENT_VERSION
-    """Version of the data writer utility scripts. Uses semantic versioning (e.g. v1.0.0)"""
+    """Version of the data writer utility scripts. Uses semantic versioning (e.g. v1.1.0)"""
 
     # Exclude these three fields from auto-encode/decode, because they need to be structured
     # together under the frameDims subfield and not as their own root-level fields.
@@ -263,7 +263,7 @@ class CollectionMetadata(DataClassJsonMixin):
     is rewritten, starting at 0.
     """
     _writer_version: Optional[str] = CURRENT_VERSION
-    """Version of the data writer utility scripts. Uses semantic versioning (e.g. v1.0.0)"""
+    """Version of the data writer utility scripts. Uses semantic versioning (e.g. v1.1.0)"""
 
 
 class CollectionDatasetEntry(TypedDict):

--- a/documentation/DATA_FORMAT.md
+++ b/documentation/DATA_FORMAT.md
@@ -1,6 +1,6 @@
 # Timelapse-Colorizer Data Format
 
-Last release: v1.0.0
+Last release: v1.1.0
 
 Timelapse-Colorizer can only load datasets that follow the defined data specification.
 


### PR DESCRIPTION
Packages new changes to the collection + dataset JSON schema as a new minor package version, v1.1.0.

*Estimated review size: tiny, <5 minutes*

Changelog:
#37
- Updates `DATA_FORMAT.md` with the new planned metadata for collections and datasets.
- Adds new base types for shared metadata.
- Adds new dictionary types for the collection file.

#38
- `ColorizerDatasetWriter` will now (correctly) load in and update metadata from existing manifests.
  - Some fields (like the revision number, time last modified, and writer version) will be updated automatically. 
  - Some fields (like the name and time of creation) will be updated if missing.

#39
- `update_collection()` auto-converts collection arrays into objects.
- `update_collection()` can also take in metadata, and update the relevant fields automatically.
- Creates a new `update_metadata()` method for shared behavior, moved from `writer.py`.
- Adds unit tests for new behavior.