### PR TITLE
feat: Validate feature keys

### DIFF
--- a/colorizer_data/tests/test_utils.py
+++ b/colorizer_data/tests/test_utils.py
@@ -12,6 +12,7 @@ from colorizer_data.types import (
 )
 from colorizer_data.utils import (
     cast_feature_to_info_type,
+    get_duplicate_items,
     infer_feature_type,
     merge_dictionaries,
     replace_out_of_bounds_values_with_nan,
@@ -395,3 +396,15 @@ def test_merge_dictionaries_handles_nesting():
     assert result["2"]["1"]["2"] == "a"
     assert result["2"]["2"] == "b"
     assert result["3"]["1"] == "a"
+
+
+def test_get_duplicates():
+    assert get_duplicate_items([]) == []
+
+    assert get_duplicate_items(["a"]) == []
+    assert get_duplicate_items(["a", "b", "c"]) == []
+
+    assert get_duplicate_items(["a", "a"]) == ["a"]
+    assert get_duplicate_items(["a", "b", "c", "c", "d", "b", "c"]) == ["b", "c"]
+
+    assert get_duplicate_items(["c", "b", "a", "a", "c", "b"]) == ["c", "b", "a"]

--- a/colorizer_data/tests/test_writer.py
+++ b/colorizer_data/tests/test_writer.py
@@ -5,7 +5,13 @@ from typing import Optional, Tuple
 import numpy as np
 import pytest
 
-from colorizer_data.types import CURRENT_VERSION, ColorizerMetadata, DatasetManifest
+from colorizer_data.types import (
+    CURRENT_VERSION,
+    ColorizerMetadata,
+    DatasetManifest,
+    FeatureInfo,
+    FeatureMetadata,
+)
 from colorizer_data.writer import ColorizerDatasetWriter
 
 DEFAULT_DATASET_NAME = "dataset"
@@ -228,3 +234,33 @@ def test_writer_updates_fields_when_metadata_is_missing(blank_manifest):
         assert metadata.date_created == metadata.last_modified
         assert metadata._writer_version == CURRENT_VERSION
         assert metadata._revision == 0
+
+
+def test_writer_throws_error_on_duplicate_feature_keys(tmp_path):
+    writer = ColorizerDatasetWriter(tmp_path, DEFAULT_DATASET_NAME)
+    setup_dummy_writer_data(writer)
+
+    feature_1_info = FeatureInfo(key="feature_1", label="Feature 1")
+    writer.write_feature(np.array([0, 1, 2, 3]), feature_1_info)
+    feature_2_info = FeatureInfo(key="feature_1", label="Feature 2")
+    writer.write_feature(np.array([0, 1, 2, 3]), feature_2_info)
+
+    with pytest.raises(RuntimeError):
+        writer.write_manifest()
+
+
+def test_writer_overwrites_duplicate_backdrop_keys(tmp_path):
+    writer = ColorizerDatasetWriter(tmp_path, DEFAULT_DATASET_NAME)
+    setup_dummy_writer_data(writer)
+
+    writer.add_backdrops("Backdrop 1", [], "shared_backdrop_key")
+    writer.add_backdrops("Backdrop 2", [], "shared_backdrop_key")
+
+    writer.write_manifest()
+
+    with open(tmp_path / DEFAULT_DATASET_NAME / "manifest.json", "r") as f:
+        manifest: DatasetManifest = json.load(f)
+
+        assert len(manifest["backdrops"]) == 1
+        assert manifest["backdrops"][0]["key"] == "shared_backdrop_key"
+        assert manifest["backdrops"][0]["name"] == "Backdrop 2"

--- a/colorizer_data/tests/test_writer.py
+++ b/colorizer_data/tests/test_writer.py
@@ -240,9 +240,9 @@ def test_writer_throws_error_on_duplicate_feature_keys(tmp_path):
     writer = ColorizerDatasetWriter(tmp_path, DEFAULT_DATASET_NAME)
     setup_dummy_writer_data(writer)
 
-    feature_1_info = FeatureInfo(key="feature_1", label="Feature 1")
+    feature_1_info = FeatureInfo(key="shared_feature_key", label="Feature 1")
     writer.write_feature(np.array([0, 1, 2, 3]), feature_1_info)
-    feature_2_info = FeatureInfo(key="feature_1", label="Feature 2")
+    feature_2_info = FeatureInfo(key="shared_feature_key", label="Feature 2")
     writer.write_feature(np.array([0, 1, 2, 3]), feature_2_info)
 
     with pytest.raises(RuntimeError):
@@ -255,7 +255,6 @@ def test_writer_overwrites_duplicate_backdrop_keys(tmp_path):
 
     writer.add_backdrops("Backdrop 1", [], "shared_backdrop_key")
     writer.add_backdrops("Backdrop 2", [], "shared_backdrop_key")
-
     writer.write_manifest()
 
     with open(tmp_path / DEFAULT_DATASET_NAME / "manifest.json", "r") as f:

--- a/colorizer_data/utils.py
+++ b/colorizer_data/utils.py
@@ -1,3 +1,4 @@
+import collections
 from datetime import datetime, timezone
 import json
 import logging
@@ -625,3 +626,12 @@ def merge_dictionaries(a: T, b: T) -> T:
         elif value is not None:
             a[key] = value
     return a
+
+
+def get_duplicate_items(input: List[str]) -> List[str]:
+    """
+    Returns a list of any items in the input array that appear more than once.
+    Duplicate items are returned in order of their first appearance.
+    """
+    # Copied from https://stackoverflow.com/questions/9835762/how-do-i-find-the-duplicates-in-a-list-and-create-another-list-with-them
+    return [item for item, count in collections.Counter(input).items() if count > 1]

--- a/colorizer_data/writer.py
+++ b/colorizer_data/writer.py
@@ -49,6 +49,7 @@ class ColorizerDatasetWriter:
     manifest: DatasetManifest
     metadata: ColorizerMetadata
     backdrops: Dict[str, BackdropMetadata]
+    features: Dict[str, FeatureMetadata]
     scale: float
 
     def __init__(
@@ -82,6 +83,7 @@ class ColorizerDatasetWriter:
 
         # Clear features
         self.manifest["features"] = []
+        self.features = {}
 
         # Load backdrops from existing manifest, if applicable
         self.backdrops = {}
@@ -182,7 +184,7 @@ class ColorizerDatasetWriter:
                 replace_out_of_bounds_values_with_nan(data, 0, len(info.categories) - 1)
 
         # Fetch feature data
-        num_features = len(self.manifest["features"])
+        num_features = len(self.features.keys())
         fmin = np.nanmin(data)
         fmax = np.nanmax(data)
         filename = "feature_" + str(num_features) + ".json"
@@ -234,8 +236,17 @@ class ColorizerDatasetWriter:
                     info.get_name()
                 )
             )
-
-        self.manifest["features"].append(metadata)
+        if key in self.features.keys():
+            # Throw a warning that we are overwriting data
+            old_feature_data = self.features[key]
+            logging.warning(
+                "Feature key '{}' already exists in manifest. Feature '{}' will overwrite existing feature '{}'. Overwriting...".format(
+                    key,
+                    label,
+                    old_feature_data["name"],
+                )
+            )
+        self.features[key] = metadata
 
     def write_data(
         self,
@@ -419,14 +430,28 @@ class ColorizerDatasetWriter:
         else:
             self.manifest["metadata"] = self.metadata.to_dict()
 
-        self.validate_dataset()
-
         self.manifest["backdrops"] = list(self.backdrops.values())
+        self.manifest["features"] = list(self.features.values())
+
+        self.validate_dataset()
 
         with open(self.outpath + "/manifest.json", "w") as f:
             json.dump(self.manifest, f, indent=2)
 
         logging.info("Finished writing dataset.")
+
+    def __check_for_duplicate_keys(self, keys: List[str], key_name: str):
+        """Throws an error if duplicates are detected in the list of keys, and prints an error message to the console."""
+        duplicate_keys = get_duplicate_items(keys)
+        if len(duplicate_keys) > 0:
+            logging.error(
+                f"All {key_name} keys must be unique! The following duplicated {key_name} keys were detected:"
+            )
+            logging.error("   [" + ", ".join(duplicate_keys) + "]")
+            logging.error("Dataset writing will now halt.")
+            raise RuntimeError(
+                f"Duplicate {key_name} keys detected in dataset manifest."
+            )
 
     def write_image(
         self,
@@ -484,28 +509,13 @@ class ColorizerDatasetWriter:
 
         # TODO: Add validation for other required data files
 
-        # Check that all features are unique.
-        # TODO: Use dictionary to store features during writing?
+        # Check that all features + backdrops have unique keys. This should be guaranteed because
+        # they are stored as dictionaries before writing.
         feature_keys = [feature["key"] for feature in self.manifest["features"]]
-        duplicate_feature_keys = get_duplicate_items(feature_keys)
-        if len(duplicate_feature_keys) > 0:
-            logging.error(
-                "All feature keys must be unique! The following duplicated feature keys were detected:"
-            )
-            logging.error("   [" + ", ".join(duplicate_feature_keys) + "]")
-            logging.error("Dataset writing will now halt.")
-            raise RuntimeError("Duplicate feature keys detected in dataset manifest.")
-
-        # Should not happen because we are using a dictionary to store backdrops :)
-        backdrop_keys = [backdrop["key"] for backdrop in self.manifest["backdrops"]]
-        duplicate_backdrop_keys = get_duplicate_items(backdrop_keys)
-        if len(duplicate_backdrop_keys) > 0:
-            logging.error(
-                "All backdrop keys must be unique! The following duplicated backdrop keys were detected:"
-            )
-            logging.error("   [" + ", ".join(duplicate_backdrop_keys) + "]")
-            logging.error("Dataset writing will now halt.")
-            raise RuntimeError("Duplicate backdrop keys detected in dataset manifest.")
+        self.__check_for_duplicate_keys(feature_keys, "feature")
+        if "backdrops" in self.manifest.keys():
+            backdrop_keys = [backdrop["key"] for backdrop in self.manifest["backdrops"]]
+            self.__check_for_duplicate_keys(backdrop_keys, "backdrop")
 
         if self.manifest["frames"] is None:
             logging.warning(

--- a/colorizer_data/writer.py
+++ b/colorizer_data/writer.py
@@ -1,3 +1,4 @@
+import collections
 import json
 import logging
 import multiprocessing
@@ -482,6 +483,22 @@ class ColorizerDatasetWriter:
             )
 
         # TODO: Add validation for other required data files
+
+        # Check that all features are unique.
+        feature_keys = [feature["key"] for feature in self.manifest["features"]]
+        if len(feature_keys) != len(set(feature_keys)):
+            # Copied from https://stackoverflow.com/questions/9835762/how-do-i-find-the-duplicates-in-a-list-and-create-another-list-with-them
+            duplicates = [
+                item
+                for item, count in collections.Counter(feature_keys).items()
+                if count > 1
+            ]
+            logging.error(
+                "All feature keys must be unique! The following duplicated feature keys were detected:"
+            )
+            logging.error("   [" + ", ".join(duplicates) + "]")
+            logging.error("Dataset writing will now halt.")
+            raise RuntimeError("Duplicate feature keys detected in dataset manifest.")
 
         if self.manifest["frames"] is None:
             logging.warning(


### PR DESCRIPTION
*Estimated review size: small, 15 minutes*

Adds a check for duplicated feature keys when writing the dataset manifest! This can cause unexpected behavior in the frontend UI (essentially, deleting all but one of the features with duplicated keys).

- Adds a check for duplicated feature and backdrop keys during manifest writing. If encountered, throws an error.
- Refactors features to be stored in a dictionary until the manifest is written to prevent key name collisions.
- Adds unit tests for feature key and backdrop key behavior.
- Adds a utility method (`get_duplicated_items`) and unit tests for it to `utils.py`.