### PR TITLE
feat: Outliers + overrides for feature min/max

### DIFF
--- a/colorizer_data/writer.py
+++ b/colorizer_data/writer.py
@@ -140,7 +140,7 @@ class ColorizerDatasetWriter:
             data (`np.ndarray[int | float]`): The numpy array for the feature, to be written to a JSON file.
             info (`FeatureInfo`): Metadata for the feature.
             outliers (`np.ndarray`): Optional boolean array, where an object `i` is an outlier if `outliers[i] == True`.
-                Outliers will not count towards min/max calulation. Ignored if not provided.
+                Outliers will not count towards min/max calculation. Ignored if not provided.
             min (int | float): Optional override for minimum feature value. If not provided, will be calculated from `data`.
             max (int | float): Optional override for maximum feature value. If not provided, will be calculated from `data`.
 


### PR DESCRIPTION
Allows feature min/max values to exclude outliers during the calculation step, as requested by Julie and Chantelle. Also allows overriding by directly providing a min/max value.

I'll likely make a minor version release after this so I can update the data generation scripts for nucmorph as well.

*Estimated review size: small, 5-10 minutes*