### PR TITLE
feature: Write features as `.parquet` binaries

### DIFF
--- a/colorizer_data/bin/example_scripts/convert_emt_migration_data.py
+++ b/colorizer_data/bin/example_scripts/convert_emt_migration_data.py
@@ -271,7 +271,7 @@ def make_collection(output_dir="./data/", do_frames=True, scale=1, dataset=""):
     # use pandas to load data
     # a is the full collection!
     a = pd.read_csv(
-        "//allen/aics/microscopy/EMTImmunostainingResults/EMTTimelapse_7-25-23/Output_CAAX/MigratoryTracksTable_AvgColonyOverlapLessThan0.9_AllPaths.csv"
+        "./data/MigratoryTracksTable_AvgColonyOverlapLessThan0.9_AllPaths.csv"
     )
 
     if dataset != "":

--- a/colorizer_data/bin/example_scripts/convert_emt_migration_data.py
+++ b/colorizer_data/bin/example_scripts/convert_emt_migration_data.py
@@ -271,7 +271,7 @@ def make_collection(output_dir="./data/", do_frames=True, scale=1, dataset=""):
     # use pandas to load data
     # a is the full collection!
     a = pd.read_csv(
-        "./data/MigratoryTracksTable_AvgColonyOverlapLessThan0.9_AllPaths.csv"
+        "//allen/aics/microscopy/EMTImmunostainingResults/EMTTimelapse_7-25-23/Output_CAAX/MigratoryTracksTable_AvgColonyOverlapLessThan0.9_AllPaths.csv"
     )
 
     if dataset != "":

--- a/colorizer_data/types.py
+++ b/colorizer_data/types.py
@@ -58,6 +58,8 @@ class FeatureInfo:
     unit: str = ""
     type: FeatureType = FeatureType.INDETERMINATE
     categories: Optional[List[str]] = None
+    min: Optional[Union[int, float]] = None
+    max: Optional[Union[int, float]] = None
 
     def get_name(self) -> Union[str, None]:
         """
@@ -93,6 +95,8 @@ class FeatureMetadata(TypedDict):
     unit: str
     type: FeatureType
     categories: List[str]
+    min: Union[int, float]
+    max: Union[int, float]
 
 
 class BackdropMetadata(TypedDict):

--- a/colorizer_data/utils.py
+++ b/colorizer_data/utils.py
@@ -255,14 +255,16 @@ def update_collection(
         json.dump(collection, f)
 
 
-def write_json_or_parquet_data(
+def write_parquet_or_json_data(
     data: np.ndarray,
     outpath: str,
     filename: str,
     *,
     min: Optional[float | int] = None,
     max: Optional[float | int] = None,
-    write_parquet: bool = False,
+    write_json: bool = False,
+    parquet_compression: str = "brotli",
+    parquet_use_dictionary: bool = False,
 ) -> str:
     """
     Writes a numpy array to a JSON or Parquet file, returning the filename of the written file.
@@ -271,14 +273,18 @@ def write_json_or_parquet_data(
         data (`np.ndarray[int | float]`): The numpy array to write.
         outpath (`str`): The directory to write the file to.
         filename (`str`): The base filename to write to.
+
         min (`Optional[int | float]`): The minimum value of the data array, written only to JSON files.
         max (`Optional[int | float]`): The maximum value of the data array, written only to JSON files.
-        write_parquet (`bool`): If True, writes the data to a Parquet file. If False, writes to a JSON file.
+        write_json (`bool`): If True, writes the data as a JSON file instead of a parquet file.
+        parquet_compression (`str`): The compression algorithm to use for parquet files. Defaults to 'brotli'.
+            See https://arrow.apache.org/docs/python/parquet.html#compression-encoding-and-file-compatibility for more details.
+        parquet_use_dictionary (`bool`): If True, uses dictionary encoding for parquet files. Defaults to False.
 
     Returns:
-        The `str` filename of the written file, ending in either `.parquet` or `.json`.z
+        The `str` filename of the written file, ending in either `.parquet` or `.json`.
     """
-    if not write_parquet:
+    if write_json:
         data_json = {"data": data.tolist(), "min": min, "max": max}
         filename = "{}.json".format(filename)
         with open(outpath + "/" + filename, "w") as f:
@@ -295,8 +301,8 @@ def write_json_or_parquet_data(
         pq.write_table(
             data_arrow,
             outpath + "/" + filename,
-            compression="brotli",
-            use_dictionary=False,
+            compression=parquet_compression,
+            use_dictionary=parquet_use_dictionary,
         )
         return filename
 

--- a/colorizer_data/utils.py
+++ b/colorizer_data/utils.py
@@ -7,6 +7,7 @@ import pathlib
 import platform
 import re
 import shutil
+from types import NoneType
 from typing import Dict, List, Optional, Sequence, TypeVar, Union, Tuple
 
 import numpy as np
@@ -56,11 +57,14 @@ class NumpyValuesEncoder(json.JSONEncoder):
         ):
             return float(obj)
         elif (
-            isinstance(obj, np.int16)
+            isinstance(obj, int)
+            or isinstance(obj, np.int16)
             or isinstance(obj, np.int32)
             or isinstance(obj, np.int64)
         ):
             return int(obj)
+        elif isinstance(obj, NoneType):
+            return None
         return json.JSONEncoder.default(self, obj)
 
 

--- a/colorizer_data/utils.py
+++ b/colorizer_data/utils.py
@@ -47,9 +47,17 @@ class NumpyValuesEncoder(json.JSONEncoder):
     """Handles float32 and int64 values."""
 
     def default(self, obj):
-        if isinstance(obj, np.float32):
+        if (
+            isinstance(obj, np.float32)
+            or isinstance(obj, np.double)
+            or isinstance(obj, np.float64)
+        ):
             return float(obj)
-        elif isinstance(obj, np.int64):
+        elif (
+            isinstance(obj, np.int16)
+            or isinstance(obj, np.int32)
+            or isinstance(obj, np.int64)
+        ):
             return int(obj)
         return json.JSONEncoder.default(self, obj)
 

--- a/colorizer_data/utils.py
+++ b/colorizer_data/utils.py
@@ -259,7 +259,7 @@ def update_collection(
         json.dump(collection, f)
 
 
-def write_parquet_or_json_data(
+def write_data_array(
     data: np.ndarray,
     outpath: str,
     filename: str,

--- a/colorizer_data/utils.py
+++ b/colorizer_data/utils.py
@@ -260,8 +260,8 @@ def write_parquet_or_json_data(
     outpath: str,
     filename: str,
     *,
-    min: Optional[float | int] = None,
-    max: Optional[float | int] = None,
+    min: Union[float, int, None] = None,
+    max: Union[float, int, None] = None,
     write_json: bool = False,
     parquet_compression: str = "brotli",
     parquet_use_dictionary: bool = False,
@@ -274,8 +274,8 @@ def write_parquet_or_json_data(
         outpath (`str`): The directory to write the file to.
         filename (`str`): The base filename to write to.
 
-        min (`Optional[int | float]`): The minimum value of the data array, written only to JSON files.
-        max (`Optional[int | float]`): The maximum value of the data array, written only to JSON files.
+        min (`int | float | None`): The minimum value of the data array, written only to JSON files.
+        max (`int | float | None`): The maximum value of the data array, written only to JSON files.
         write_json (`bool`): If True, writes the data as a JSON file instead of a parquet file.
         parquet_compression (`str`): The compression algorithm to use for parquet files. Defaults to 'brotli'.
             See https://arrow.apache.org/docs/python/parquet.html#compression-encoding-and-file-compatibility for more details.

--- a/colorizer_data/utils.py
+++ b/colorizer_data/utils.py
@@ -268,7 +268,7 @@ def write_parquet_or_json_data(
     max: Union[float, int, None] = None,
     write_json: bool = False,
     parquet_compression: str = "brotli",
-    parquet_use_dictionary: bool = False,
+    parquet_use_dict: bool = False,
 ) -> str:
     """
     Writes a numpy array to a JSON or Parquet file, returning the filename of the written file.
@@ -276,17 +276,19 @@ def write_parquet_or_json_data(
     Args:
         data (`np.ndarray[int | float]`): The numpy array to write.
         outpath (`str`): The directory to write the file to.
-        filename (`str`): The base filename to write to.
+        filename (`str`): The base filename to write to. The resulting file will be named `{filename}.parquet`
+            or `{filename}.json`.
 
-        min (`int | float | None`): The minimum value of the data array, written only to JSON files.
-        max (`int | float | None`): The maximum value of the data array, written only to JSON files.
-        write_json (`bool`): If True, writes the data as a JSON file instead of a parquet file.
-        parquet_compression (`str`): The compression algorithm to use for parquet files. Defaults to 'brotli'.
+        min (`int | float | None`): The minimum value of the data array. Written only to JSON files. Defaults to None.
+        max (`int | float | None`): The maximum value of the data array. Written only to JSON files. Defaults to None.
+        write_json (`bool`): If True, writes the data as a JSON file instead of a Parquet file. False by default.
+        parquet_compression (`str`): The compression algorithm to use for Parquet files. Defaults to 'brotli'.
             See https://arrow.apache.org/docs/python/parquet.html#compression-encoding-and-file-compatibility for more details.
-        parquet_use_dictionary (`bool`): If True, uses dictionary encoding for parquet files. Defaults to False.
+        parquet_use_dict (`bool`): If True, uses dictionary encoding for parquet files; useful for large dtypes (like strings)
+            with repeated values. Defaults to False.
 
     Returns:
-        The `str` filename of the written file, ending in either `.parquet` or `.json`.
+        The `str` filename of the written file, ending in either `{filename}.parquet` or `{filename}.json`.
     """
     if write_json:
         data_json = {"data": data.tolist(), "min": min, "max": max}
@@ -306,7 +308,7 @@ def write_parquet_or_json_data(
             data_arrow,
             outpath + "/" + filename,
             compression=parquet_compression,
-            use_dictionary=parquet_use_dictionary,
+            use_dictionary=parquet_use_dict,
         )
         return filename
 

--- a/colorizer_data/writer.py
+++ b/colorizer_data/writer.py
@@ -31,7 +31,7 @@ from colorizer_data.utils import (
     MAX_CATEGORIES,
     NumpyValuesEncoder,
     update_metadata,
-    write_parquet_or_json_data,
+    write_data_array,
 )
 
 
@@ -227,7 +227,7 @@ class ColorizerDatasetWriter:
 
         # Write the feature JSON file
         logging.info("Writing {}...".format(file_basename))
-        filename = write_parquet_or_json_data(
+        filename = write_data_array(
             data,
             self.outpath,
             file_basename,
@@ -315,15 +315,15 @@ class ColorizerDatasetWriter:
             outliers (`np.ndarray`): An optional 1D numpy array of boolean values, where `outliers[i]` is `True` if the `i`th object is an outlier.
             bounds (`np.ndarray`): An optional 1D numpy array of float values. For the `i`th object, the coordinates of the upper left corner are
                 `(x: bounds[4i], y: bounds[4i + 1])` and the lower right corner are `(x: bounds[4i + 2], y: bounds[4i + 3])`.
-            write_parquet (`bool`): Whether to write the specified data as a `.parquet` file rather than the default JSON format.
-                Compatible with TFE viewer >v1.1.0. Default is `True`.
+            write_json (`bool`): Whether to write the specified data as a JSON file rather than the default Parquet format.
+                Parquet data is compatible with TFE viewer >= v1.1.0. Default is `False`.
 
         [documentation](https://github.com/allen-cell-animated/colorizer-data/blob/main/documentation/DATA_FORMAT.md#1-tracks)
         """
         # TODO check outlier and replace values with NaN or something!
         if outliers is not None:
             logging.info("Writing outliers data...")
-            track_filename = write_parquet_or_json_data(
+            track_filename = write_data_array(
                 outliers, self.outpath, "outliers", write_json=write_json
             )
             self.manifest["outliers"] = track_filename
@@ -331,14 +331,14 @@ class ColorizerDatasetWriter:
         # Note these must be in same order as features and same row order as the dataframe.
         if tracks is not None:
             logging.info("Writing track data...")
-            track_filename = write_parquet_or_json_data(
+            track_filename = write_data_array(
                 tracks, self.outpath, "tracks", write_json=write_json
             )
             self.manifest["tracks"] = track_filename
 
         if times is not None:
             logging.info("Writing times data...")
-            times_filename = write_parquet_or_json_data(
+            times_filename = write_data_array(
                 times, self.outpath, "times", write_json=write_json
             )
             self.manifest["times"] = times_filename
@@ -352,7 +352,7 @@ class ColorizerDatasetWriter:
             centroids_stacked = np.ravel(np.dstack([centroids_x, centroids_y]))
             centroids_stacked = centroids_stacked * self.scale
             centroids_stacked = centroids_stacked.astype(int)
-            centroids_filename = write_parquet_or_json_data(
+            centroids_filename = write_data_array(
                 centroids_stacked,
                 self.outpath,
                 "centroids",
@@ -362,7 +362,7 @@ class ColorizerDatasetWriter:
 
         if bounds is not None:
             logging.info("Writing bounds data...")
-            bounds_filename = write_parquet_or_json_data(
+            bounds_filename = write_data_array(
                 bounds, self.outpath, "bounds", write_json=write_json
             )
             self.manifest["bounds"] = bounds_filename

--- a/colorizer_data/writer.py
+++ b/colorizer_data/writer.py
@@ -204,7 +204,7 @@ class ColorizerDatasetWriter:
         if write_parquet:
             filename = parquet_filename
 
-        file_path = self.outpath + "/" + filename
+        parquet_file_path = self.outpath + "/" + parquet_filename
         json_file_path = self.outpath + "/" + json_filename
 
         # Calculate min/max
@@ -260,7 +260,7 @@ class ColorizerDatasetWriter:
 
         df = pd.DataFrame({"data": data})
         data_arrow = pa.Table.from_pandas(df)
-        pq.write_table(data_arrow, parquet_filename)
+        pq.write_table(data_arrow, parquet_file_path)
 
         # Update the manifest with this feature data
         # Default to column name if no label is given; throw error if neither is present

--- a/colorizer_data/writer.py
+++ b/colorizer_data/writer.py
@@ -252,6 +252,9 @@ class ColorizerDatasetWriter:
             metadata["categories"] = info.categories
             # TODO cast to int, but handle NaN?
 
+        if data.dtype == np.float64 or data.dtype == np.double:
+            data = data.astype(np.float32)
+
         # Write the feature JSON file
         logging.info("Writing {}...".format(json_filename))
         js = {"data": data.tolist(), "min": fmin, "max": fmax}

--- a/colorizer_data/writer.py
+++ b/colorizer_data/writer.py
@@ -259,7 +259,7 @@ class ColorizerDatasetWriter:
             json.dump(js, f, cls=NumpyValuesEncoder)
 
         df = pd.DataFrame({"data": data})
-        data_arrow = pa.Table.from_pandas(df)
+        data_arrow = pa.Table.from_pandas(df, preserve_index=False)
         pq.write_table(data_arrow, parquet_file_path)
 
         # Update the manifest with this feature data

--- a/colorizer_data/writer.py
+++ b/colorizer_data/writer.py
@@ -8,6 +8,7 @@ from typing import Dict, List, Union
 
 import numpy as np
 from PIL import Image
+
 from colorizer_data.types import (
     BackdropMetadata,
     ColorizerMetadata,
@@ -16,7 +17,6 @@ from colorizer_data.types import (
     FeatureMetadata,
     FeatureType,
 )
-
 from colorizer_data.utils import (
     DEFAULT_FRAME_PREFIX,
     DEFAULT_FRAME_SUFFIX,
@@ -130,8 +130,6 @@ class ColorizerDatasetWriter:
         info: FeatureInfo,
         *,
         outliers: Union[np.ndarray, None] = None,
-        min: Union[int, float, None] = None,
-        max: Union[int, float, None] = None,
     ) -> None:
         """
         Writes a feature data array and stores feature metadata to be written to the manifest.
@@ -203,11 +201,11 @@ class ColorizerDatasetWriter:
         filtered_data = data
         if outliers is not None:
             filtered_data = data[np.logical_not(outliers)]
-        fmin = min
-        fmax = max
-        if min is None:
+        fmin = info.min
+        fmax = info.max
+        if fmin is None:
             fmin = np.nanmin(filtered_data)
-        if max is None:
+        if fmax is None:
             fmax = np.nanmax(filtered_data)
 
         key = info.key
@@ -222,6 +220,8 @@ class ColorizerDatasetWriter:
             "unit": info.unit,
             "type": info.type,
             "key": key,
+            "min": fmin,
+            "max": fmax,
         }
 
         # Add categories to metadata only if feature is categorical; also do validation here

--- a/colorizer_data/writer.py
+++ b/colorizer_data/writer.py
@@ -252,6 +252,7 @@ class ColorizerDatasetWriter:
             metadata["categories"] = info.categories
             # TODO cast to int, but handle NaN?
 
+        # The viewer reads float data as float32, so cast it if needed.
         if data.dtype == np.float64 or data.dtype == np.double:
             data = data.astype(np.float32)
 
@@ -263,6 +264,10 @@ class ColorizerDatasetWriter:
 
         df = pd.DataFrame({"data": data})
         data_arrow = pa.Table.from_pandas(df, preserve_index=False)
+        # TODO: Do some calculation to determine whether to use a dictionary here. There are some
+        # cases where the dictionary doubles the file size compared to a plain encoding.
+        # See https://parquet.apache.org/docs/file-format/data-pages/encodings/ for details... it looks like
+        # it already does some determination of whether to use dictionary encoding by default?
         pq.write_table(data_arrow, parquet_file_path)
 
         # Update the manifest with this feature data

--- a/colorizer_data/writer.py
+++ b/colorizer_data/writer.py
@@ -268,7 +268,65 @@ class ColorizerDatasetWriter:
         # cases where the dictionary doubles the file size compared to a plain encoding.
         # See https://parquet.apache.org/docs/file-format/data-pages/encodings/ for details... it looks like
         # it already does some determination of whether to use dictionary encoding by default?
+        parquet_format_file_path = (
+            self.outpath + "/" + "{}-feature_" + str(num_features) + ".parquet"
+        )
         pq.write_table(data_arrow, parquet_file_path)
+        pq.write_table(
+            data_arrow,
+            parquet_format_file_path.format("dict-snappy"),
+            use_dictionary=True,
+        )
+        pq.write_table(
+            data_arrow,
+            parquet_format_file_path.format("no_dict-snappy"),
+            use_dictionary=False,
+        )
+        pq.write_table(
+            data_arrow, parquet_format_file_path.format("gzip"), compression="gzip"
+        )
+        pq.write_table(
+            data_arrow, parquet_format_file_path.format("brotli"), compression="brotli"
+        )
+        pq.write_table(
+            data_arrow, parquet_format_file_path.format("zstd"), compression="zstd"
+        )
+        pq.write_table(
+            data_arrow, parquet_format_file_path.format("lz4"), compression="lz4"
+        )
+        pq.write_table(
+            data_arrow, parquet_format_file_path.format("none"), compression="none"
+        )
+        pq.write_table(
+            data_arrow,
+            parquet_format_file_path.format("no_dict-gzip"),
+            compression="gzip",
+            use_dictionary=False,
+        )
+        pq.write_table(
+            data_arrow,
+            parquet_format_file_path.format("no_dict-brotli"),
+            compression="brotli",
+            use_dictionary=False,
+        )
+        pq.write_table(
+            data_arrow,
+            parquet_format_file_path.format("no_dict-zstd"),
+            compression="zstd",
+            use_dictionary=False,
+        )
+        pq.write_table(
+            data_arrow,
+            parquet_format_file_path.format("no_dict-lz4"),
+            compression="lz4",
+            use_dictionary=False,
+        )
+        pq.write_table(
+            data_arrow,
+            parquet_format_file_path.format("no_dict-none"),
+            compression="none",
+            use_dictionary=False,
+        )
 
         # Update the manifest with this feature data
         # Default to column name if no label is given; throw error if neither is present

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,13 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
+    "dataclasses-json",
     "numpy",
     "pandas",
     "pillow",
+    "pyarrow",
     "scikit-image",
     "requests",
-    "dataclasses-json",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Closes https://github.com/allen-cell-animated/timelapse-colorizer/issues/401, writing data arrays as binary data to speed up the load times of datasets. After some research, we settled on the Apache Parquet format, since we already use it internally and it's recognized by a lot of the scientific community.

I've tested with the NucMorph datasets and found that, altogether, the new feature files are 10% the size they used to be! The amount of compression varies pretty widely based on the type of data though.

*Estimated review size: medium, 20-30 minutes*

## Changes
- Moves feature min/max from the feature JSON files to the dataset manifest JSON. (This allows the JSON/parquet files to only hold data.)
- Adds an option to save files in the `.parquet` format in `ColorizerDataWriter.write_feature()` and `ColorizerDataWriter.write_data()`.
- Adds unit tests for writing JSON and Parquet data.

## Validation
- Comparison dataset you can view in a viewer branch: https://allen-cell-animated.github.io/timelapse-colorizer/pr-preview/pr-409/viewer?collection=https%3A%2F%2Fdev-aics-dtp-001.int.allencell.org%2Fdan-data%2Fcolorizer%2Fdata%2Ftest%2Fparquet%2Fcollection.json&dataset=Medium+JSON