### PR TITLE
fix: Added additional checks for numpy values

### DIFF
--- a/colorizer_data/utils.py
+++ b/colorizer_data/utils.py
@@ -7,6 +7,7 @@ import pathlib
 import platform
 import re
 import shutil
+from types import NoneType
 from typing import Dict, List, Optional, Sequence, TypeVar, Union, Tuple
 
 import numpy as np
@@ -47,10 +48,20 @@ class NumpyValuesEncoder(json.JSONEncoder):
     """Handles float32 and int64 values."""
 
     def default(self, obj):
-        if isinstance(obj, np.float32):
+        if (
+            isinstance(obj, np.float32)
+            or isinstance(obj, np.double)
+            or isinstance(obj, np.float64)
+        ):
             return float(obj)
-        elif isinstance(obj, np.int64):
+        elif (
+            isinstance(obj, np.int16)
+            or isinstance(obj, np.int32)
+            or isinstance(obj, np.int64)
+        ):
             return int(obj)
+        elif isinstance(obj, NoneType):
+            return None
         return json.JSONEncoder.default(self, obj)
 
 


### PR DESCRIPTION
Fixes a bug where numpy values in formats other than float32 would cause a crash when writing data. Pulling this out from the two other PRs where I separately added this fix.