### PR TITLE
fix: Fixed bug where NoneType is not recognized

### DIFF
--- a/colorizer_data/utils.py
+++ b/colorizer_data/utils.py
@@ -7,7 +7,6 @@ import pathlib
 import platform
 import re
 import shutil
-from types import NoneType
 from typing import Dict, List, Optional, Sequence, TypeVar, Union, Tuple
 
 import numpy as np
@@ -63,7 +62,7 @@ class NumpyValuesEncoder(json.JSONEncoder):
             or isinstance(obj, np.int64)
         ):
             return int(obj)
-        elif isinstance(obj, NoneType):
+        elif obj is None:
             return None
         return json.JSONEncoder.default(self, obj)
 


### PR DESCRIPTION
Fixes a bug Chantelle was running into where `NoneType` was not being recognized in Python 3.9. This seems to be fixed in Python 3.10, but I've just done a `var is None` check instead to remove the dependency.

*Estimated size: 1 minute, tiny*