### PR TITLE
doc: Added PR and issue ticket templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: '"Something''s wrong..."'
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Description
+
+_A clear description of the bug_
+
+## Expected Behavior
+
+_What did you expect to happen instead?_
+
+## Reproduction
+
+_A minimal example that exhibits the behavior._
+
+## Environment
+
+_Any additional information about your environment. E.g. OS version, python version, browser etc._

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature Request
+about: '"It would be really cool if x did y..."'
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Use Case
+
+_Please provide a use case to help us understand your request in context_
+
+## Acceptance Criteria
+
+_Please describe how you know this is done_
+
+## Details
+
+_Please provide any helpful specifications_
+

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+Problem
+=======
+What is the problem this work solves, including
+[Link to story or ticket](https://my-tracking-system.url/ticket-number)
+
+Solution
+========
+What I/we did to solve this problem
+
+with @pairperson1
+
+## Type of change
+Please delete options that are not relevant.
+
+* Bug fix (non-breaking change which fixes an issue)
+* New feature (non-breaking change which adds functionality)
+* Breaking change (fix or feature that would cause existing functionality to not work as expected)
+* This change requires a documentation update
+* This change requires updated or new tests
+
+Change summary:
+---------------
+* Tidy, well formulated commit message
+* Another great commit message
+* Something else I/we did
+
+Steps to Verify:
+----------------
+1. A setup step / beginning state
+1. What to do next
+1. Any other instructions
+1. Expected behavior
+1. Suggestions for testing
+
+Screenshots (optional):
+-----------------------
+Show-n-tell images/animations here
+
+Keyfiles (delete if not relevant):
+-----------------------
+1. main file/entry point
+2. other important file
+
+Thanks for contributing!


### PR DESCRIPTION
Closes #74. Adds templates for PRs and issue tickets, copied from our other repositories.

*Estimated review size: tiny, <5 minutes*