### PR TITLE
fix: Ignore `Infinity` when calculating feature min/max

### DIFF
--- a/colorizer_data/utils.py
+++ b/colorizer_data/utils.py
@@ -51,11 +51,17 @@ class NumpyValuesEncoder(json.JSONEncoder):
 
     def default(self, obj):
         if (
-            isinstance(obj, np.float32)
+            isinstance(obj, float)
+            or isinstance(obj, np.float32)
             or isinstance(obj, np.double)
             or isinstance(obj, np.float64)
         ):
-            return float(obj)
+            if np.isposinf(obj):
+                return "Infinity"
+            elif np.isneginf(obj):
+                return "-Infinity"
+            else:
+                return float(obj)
         elif (
             isinstance(obj, int)
             or isinstance(obj, np.int16)
@@ -65,6 +71,8 @@ class NumpyValuesEncoder(json.JSONEncoder):
             return int(obj)
         elif obj is None:
             return None
+        elif isinstance(obj, str):
+            return obj
         return json.JSONEncoder.default(self, obj)
 
 

--- a/colorizer_data/writer.py
+++ b/colorizer_data/writer.py
@@ -232,9 +232,23 @@ class ColorizerDatasetWriter:
         fmin = encoder.default(info.min)
         fmax = encoder.default(info.max)
         if fmin is None:
-            fmin = np.nanmin(filtered_data)
+            try:
+                fmin = np.nanmin(filtered_data)
+            except ValueError:
+                raise ValueError(
+                    "ColorizerDatasetWriter.write_feature: Feature '{}' has no finite, non-outlier values.".format(
+                        info.get_name()
+                    )
+                )
         if fmax is None:
-            fmax = np.nanmax(filtered_data)
+            try:
+                fmax = np.nanmax(filtered_data)
+            except ValueError:
+                raise ValueError(
+                    "ColorizerDatasetWriter.write_feature: Feature '{}' has no finite, non-outlier values.".format(
+                        info.get_name()
+                    )
+                )
         fmin = encoder.default(fmin)
         fmax = encoder.default(fmax)
 

--- a/colorizer_data/writer.py
+++ b/colorizer_data/writer.py
@@ -231,7 +231,6 @@ class ColorizerDatasetWriter:
         encoder = NumpyValuesEncoder()
         fmin = encoder.default(info.min)
         fmax = encoder.default(info.max)
-        print(fmin, fmax)
         if fmin is None:
             try:
                 fmin = np.nanmin(filtered_data)
@@ -240,7 +239,7 @@ class ColorizerDatasetWriter:
                     "ColorizerDatasetWriter.write_feature: Feature '{}' had no finite, non-outlier values when calculating min/max bounds.".format(
                         info.get_name()
                     )
-                    + " Provide a min and max in FeatureInfo to override automatic bounds calculation."
+                    + " Provide a min and max property in FeatureInfo to override automatic bounds calculation."
                 )
             fmin = encoder.default(fmin)
         if fmax is None:
@@ -251,7 +250,7 @@ class ColorizerDatasetWriter:
                     "ColorizerDatasetWriter.write_feature: Feature '{}' has no finite, non-outlier values when calculating min/max bounds.".format(
                         info.get_name()
                     )
-                    + " Provide a min and max in FeatureInfo to override automatic bounds calculation."
+                    + " Provide a min and max property in FeatureInfo to override automatic bounds calculation."
                 )
             fmax = encoder.default(fmax)
 

--- a/colorizer_data/writer.py
+++ b/colorizer_data/writer.py
@@ -226,6 +226,8 @@ class ColorizerDatasetWriter:
         filtered_data = data
         if outliers is not None:
             filtered_data = data[np.logical_not(outliers)]
+        # Exclude NaN + Infinity values from min/max calculation
+        filtered_data = filtered_data[np.isfinite(filtered_data)]
         encoder = NumpyValuesEncoder()
         fmin = encoder.default(info.min)
         fmax = encoder.default(info.max)

--- a/colorizer_data/writer.py
+++ b/colorizer_data/writer.py
@@ -231,26 +231,29 @@ class ColorizerDatasetWriter:
         encoder = NumpyValuesEncoder()
         fmin = encoder.default(info.min)
         fmax = encoder.default(info.max)
+        print(fmin, fmax)
         if fmin is None:
             try:
                 fmin = np.nanmin(filtered_data)
             except ValueError:
                 raise ValueError(
-                    "ColorizerDatasetWriter.write_feature: Feature '{}' has no finite, non-outlier values.".format(
+                    "ColorizerDatasetWriter.write_feature: Feature '{}' had no finite, non-outlier values when calculating min/max bounds.".format(
                         info.get_name()
                     )
+                    + " Provide a min and max in FeatureInfo to override automatic bounds calculation."
                 )
+            fmin = encoder.default(fmin)
         if fmax is None:
             try:
                 fmax = np.nanmax(filtered_data)
             except ValueError:
                 raise ValueError(
-                    "ColorizerDatasetWriter.write_feature: Feature '{}' has no finite, non-outlier values.".format(
+                    "ColorizerDatasetWriter.write_feature: Feature '{}' has no finite, non-outlier values when calculating min/max bounds.".format(
                         info.get_name()
                     )
+                    + " Provide a min and max in FeatureInfo to override automatic bounds calculation."
                 )
-        fmin = encoder.default(fmin)
-        fmax = encoder.default(fmax)
+            fmax = encoder.default(fmax)
 
         # The viewer reads float data as float32, so cast it if needed.
         if data.dtype == np.float64 or data.dtype == np.double:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -340,7 +340,6 @@ class TestWriteFeature:
                 assert feature_data["data"] == [0, 1, 2, 3, 4]
 
     def test_writer_throws_error_if_feature_has_no_finite_values(self, tmp_path):
-        # Test that an error is raised when min > max
         writer = ColorizerDatasetWriter(tmp_path, DEFAULT_DATASET_NAME)
         setup_dummy_writer_data(writer)
 
@@ -349,7 +348,6 @@ class TestWriteFeature:
             writer.write_feature(np.array([-np.inf, np.nan, np.inf]), feature_info)
 
     def test_writer_throws_error_if_feature_has_only_outlier_values(self, tmp_path):
-        # Test that an error is raised when min > max
         writer = ColorizerDatasetWriter(tmp_path, DEFAULT_DATASET_NAME)
         setup_dummy_writer_data(writer)
 

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -271,6 +271,29 @@ def test_writer_overwrites_duplicate_backdrop_keys(tmp_path):
         assert manifest["backdrops"][0]["name"] == "Backdrop 2"
 
 
+def test_writer_ignores_infinity_values_for_feature_min_max(tmp_path):
+    # Test that infinity values are ignored when calculating min/max
+    writer = ColorizerDatasetWriter(tmp_path, DEFAULT_DATASET_NAME)
+    setup_dummy_writer_data(writer)
+
+    feature_info = FeatureInfo(key="feature", label="Feature")
+    writer.write_feature(
+        np.array([0, 1, 2, np.inf, -np.inf, 4]),
+        feature_info,
+        write_json=True,
+    )
+    writer.write_manifest()
+
+    with open(tmp_path / DEFAULT_DATASET_NAME / "manifest.json", "r") as f:
+        manifest: DatasetManifest = json.load(f)
+        feature_file = manifest["features"][0]["data"]
+        with open(tmp_path / DEFAULT_DATASET_NAME / feature_file, "r") as f2:
+            feature_data = json.load(f2)
+            assert feature_data["min"] == 0
+            assert feature_data["max"] == 4
+            assert feature_data["data"] == [0, 1, 2, np.inf, -np.inf, 4]
+
+
 class TestWriteFeature:
     def test_write_feature_ignores_outliers_when_calculating_feature_min_max(
         self, tmp_path


### PR DESCRIPTION
Problem
=======
Closes #85, "do not write Infinity/-Infinity as feature min/max."

Fixes a bug reported by Chantelle where Infinity values would be written to the dataset, which would then cause the JSON dataset parsing to fail because Infinity/-Infinity are not valid JSON numbers.

*Estimated review size: small, 10 minutes*

Solution
========
- Updated `write_feature` so auto min/max calculation ignores non-finite values.
  - Throws an error if automatic feature calculation is enabled but no finite, non-outlier values are provided.
- Added serialization for Infinity values if manually passed in as bounds.
- Updated unit tests
 
## Type of change
* Bug fix (non-breaking change which fixes an issue)
