### PR TITLE
try a very basic https server

### DIFF
--- a/colorizer_data/serve_https.py
+++ b/colorizer_data/serve_https.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""
+Drop-in replacement for `python -m http.server`, but over HTTPS.
+
+Usage:
+    python -m https_server [port] [--directory DIR]
+
+Default port is 4443.
+"""
+
+import sys
+import ssl
+import http.server
+import tempfile
+import atexit
+import os
+import datetime
+import argparse
+from functools import partial
+
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+def generate_self_signed_cert():
+    """Generate a temporary self-signed cert + key and return their file paths."""
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(subject)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(datetime.datetime.utcnow() - datetime.timedelta(days=1))
+        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=1))
+        .sign(key, hashes.SHA256())
+    )
+
+    cert_file = tempfile.NamedTemporaryFile(delete=False)
+    key_file = tempfile.NamedTemporaryFile(delete=False)
+
+    atexit.register(os.remove, cert_file.name)
+    atexit.register(os.remove, key_file.name)
+
+    cert_file.write(cert.public_bytes(serialization.Encoding.PEM))
+    cert_file.close()
+
+    key_file.write(
+        key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        )
+    )
+    key_file.close()
+
+    return cert_file.name, key_file.name
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Simple HTTPS server (self-signed cert)."
+    )
+    parser.add_argument(
+        "port",
+        type=int,
+        nargs="?",
+        default=4443,
+        help="Port to serve on (default: 4443)",
+    )
+    parser.add_argument(
+        "--directory",
+        "-d",
+        default=".",
+        help="Directory to serve (default: current dir)",
+    )
+    args = parser.parse_args()
+
+    cert_path, key_path = generate_self_signed_cert()
+
+    handler_class = partial(
+        http.server.SimpleHTTPRequestHandler, directory=args.directory
+    )
+    httpd = http.server.HTTPServer(("0.0.0.0", args.port), handler_class)
+
+    # Modern SSL API
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certfile=cert_path, keyfile=key_path)
+    httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
+
+    print(f"Serving HTTPS on https://0.0.0.0:{args.port} (directory: {args.directory})")
+    httpd.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "bioio-ome-tiff >= 1.0.0",
     "bioio-tifffile",
     "bioio-ome-zarr",
+    "cryptography",
     "dataclasses-json",
     "numpy",
     "pandas",


### PR DESCRIPTION
Problem
=======
Users who creating datasets for the first time locally can have a hard time viewing them in tfe.allencell.org due to https requirement.  This would provide a one-line Python script that can serve a local dataset over https from the directory where it lives.

Solution
========
Add a python script you can run to serve a directory over https.


## Type of change

* New feature (non-breaking change which adds functionality)
* This change requires a documentation update

Change summary:
---------------
The certificate that is auto generated is not "trusted" and so your browser will let you know, and you'll have to e.g. click through the "Advanced" button in Chrome.   In order to get a trusted one, you would need to use a separate program like mkcert, I believe.  Haven't looked into that option yet.

Steps to Verify:
----------------
run the script, and try https fetching a file from the directory.  
`python serve_https.py`
then in browser, visit https://localhost:4443/types.py (for example)

