### PR TITLE
fix:  Prevent browser from caching files while using `tfe-open`

### DIFF
--- a/colorizer_data/bin/tfe_open.py
+++ b/colorizer_data/bin/tfe_open.py
@@ -210,7 +210,7 @@ class CORSRequestHandler(SimpleHTTPRequestHandler):
         self.send_header(
             "Cache-Control", "no-cache, no-store, must-revalidate, max-age=0"
         )
-        self.send_header("Pragma", "no-cache")
+        self.send_header("Pragma", "no-cache")  # For compatibility with HTTP/1.0
         self.send_header("Expires", "0")
         SimpleHTTPRequestHandler.end_headers(self)
 

--- a/colorizer_data/bin/tfe_open.py
+++ b/colorizer_data/bin/tfe_open.py
@@ -207,7 +207,9 @@ class CORSRequestHandler(SimpleHTTPRequestHandler):
         # Allow CORS for all domains
         self.send_header("Access-Control-Allow-Origin", "*")
         # Request browser not to cache files
-        self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
+        self.send_header(
+            "Cache-Control", "no-cache, no-store, must-revalidate, max-age=0"
+        )
         self.send_header("Pragma", "no-cache")
         self.send_header("Expires", "0")
         SimpleHTTPRequestHandler.end_headers(self)


### PR DESCRIPTION
Problem
=======

Some updates to improve user experience, based on observations from Max Hess. We were running into an issue where the `tfe-open` server appeared to hang, and also browsers would cache stale data.

https://stackoverflow.com/questions/43146298/http-request-from-chrome-hangs-python-webserver
https://gist.github.com/opyate/6e5fcabc6f41474d248613c027373856

*Estimated review size: tiny, <5 minutes*

Solution
========
- Changed request handler from HTTPServer to include headers indicating that browsers should not cache files
- Changed server type from `HTTPServer` to `ThreadingHTTPServer` to handle 

## Type of change
Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)
